### PR TITLE
feat: configure job to create ES256 JWKs

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,4 +2,11 @@
 
 ## Versions
 
-####    1.0.0 - Iris-Hydra init version
+## [1.0.1]
+### Changed
+- Configured K8s Jobs to generate JWKs with the ES256 algorithm 
+    - A separate Job is created for each realm 
+    - Jobs can be enabled by setting the `job.jwk.enabled` flag to `true` in the `values.yaml` file
+    - Jobs access Iris-Hydra admin endpoint directly 
+
+## [1.0.0] - Iris-Hydra init version

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "2.3.0"
 name: iris-hydra
 description: A Helm chart for Iris-Hydra
 type: application
-version: 1.0.0
+version: 1.0.1
 keywords:
   - hydra
   - oauth2

--- a/scripts/jwks-create.sh
+++ b/scripts/jwks-create.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+set -e
+
+echo "Creating ES256 JWKs in realm: $REALM_NAME"
+echo "Hydra admin endpoint: $HYDRA_ADMIN_SERVICE_PATH"
+
+ACCESS_TOKEN_JWK=$(hydra get jwk hydra.jwt.access-token --endpoint $HYDRA_ADMIN_SERVICE_PATH 2>&1 || true)
+
+echo "🔑 Creating new ES256 access token key (hydra.jwt.access-token)..."
+if echo "$ACCESS_TOKEN_JWK" | grep -q '"error": "Not Found"' || ! echo "$ACCESS_TOKEN_JWK" | grep -q "ES256"; then
+  hydra create jwk hydra.jwt.access-token --alg ES256 --use sig --endpoint $HYDRA_ADMIN_SERVICE_PATH || exit 1
+  echo "✅ New ES256 key for access token created."
+elif echo "$ACCESS_TOKEN_JWK" | grep -q "ES256"; then
+  echo "✅ ES256 key for access token already exists. Skipping creation."
+else
+  echo "❌ Unexpected response: $ACCESS_TOKEN_JWK"
+  exit 1
+fi
+
+ID_TOKEN_JWK=$(hydra get jwk hydra.openid.id-token --endpoint $HYDRA_ADMIN_SERVICE_PATH 2>&1 || true)
+
+echo "🔑 Creating new ES256 ID token key (hydra.openid.id-token)..."
+if echo "$ID_TOKEN_JWK" | grep -q '"error": "Not Found"' || ! echo "$ID_TOKEN_JWK" | grep -q "ES256"; then
+  hydra create jwk hydra.openid.id-token --alg ES256 --use sig --endpoint $HYDRA_ADMIN_SERVICE_PATH || exit 1
+  echo "✅ New ES256 key for ID token created."
+elif echo "$ID_TOKEN_JWK" | grep -q "ES256"; then
+  echo "✅ ES256 key for ID token already exists. Skipping creation."
+else
+  echo "❌ Unexpected response: $ID_TOKEN_JWK"
+  exit 1
+fi
+
+echo ""
+echo "Fetching updated access token keys (hydra.jwt.access-token)..."
+hydra get jwk hydra.jwt.access-token --endpoint $HYDRA_ADMIN_SERVICE_PATH || exit 1
+
+echo ""
+echo "Fetching updated ID token keys (hydra.openid.id-token)..."
+hydra get jwk hydra.openid.id-token --endpoint $HYDRA_ADMIN_SERVICE_PATH || exit 1

--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -11,3 +11,5 @@ metadata:
 data:
   "config.yaml": |
 {{ include "iris.configmap" . | nindent 4 }}
+  "jwks-create.sh": |
+{{ tpl (.Files.Get "scripts/jwks-create.sh") . | indent 4 }}

--- a/templates/job-jwks.yaml
+++ b/templates/job-jwks.yaml
@@ -1,11 +1,14 @@
 {{/* SPDX-FileCopyrightText: 2025 Deutsche Telekom AG
 
  SPDX-License-Identifier: Apache-2.0*/}}
-{{- if and .Values.job.jwk.enabled (gt (int .Values.replicaCount) 0) }}
+{{- if .Values.job.jwk.enabled }}
+{{- range $realmName, $realm := .Values.realm }}
+{{- if or (not (hasKey $realm "replicaCount")) (gt (int $realm.replicaCount) 0) }}
+{{- with $ }}
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ include "iris.fullname" . }}-jwks
+  name: {{ include "iris.fullname" . }}-jwks-{{ $realmName }}
   namespace: {{ .Release.Namespace }}
   annotations:
     argocd.argoproj.io/hook: PostSync
@@ -26,62 +29,24 @@ spec:
             {{- toYaml .Values.deployment.securityContext.container | nindent 12 }}
           image: "{{ include "imageRef" .Values.component.hydra.image }}"
           env:
-            {{- if .Values.component.sidecar.enabled }}
-            - name: HYDRA_HYDRA_USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Release.Name }}-admin
-                  key: HYDRA_ADMIN_USERNAME
-            - name: HYDRA_ADMIN_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Release.Name }}-admin
-                  key: HYDRA_ADMIN_PASSWORD
-            {{- end }}
-          command: [ "/bin/sh" ]
+            - name: REALM_NAME
+              value: "{{ $realmName }}"
+            - name: HYDRA_ADMIN_SERVICE_PATH
+              value: "http://{{ include "iris.fullname" . }}-admin-{{ $realmName }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.admin.port }}"
+          command: [ "sh" ]
           args:
             - "-c"
-            - |
-              set -e
-              for realmName in {{ range $realmName, $realm := .Values.realm }}{{ $realmName }} {{ end }}; do
-                echo "==========================================="
-                echo "Create ES256 keys in $realmName realm"
-                HYDRA_ADMIN_SERVICE_PATH=http://{{ include "iris.fullname" . }}-admin-${realmName}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.admin.port }}
-
-                {{- if .Values.component.sidecar.enabled }}
-                BASIC_AUTH_HEADER="Authorization: Basic $(echo -n $HYDRA_HYDRA_USERNAME:$HYDRA_ADMIN_PASSWORD | base64)"
-                {{- end }}
-
-                ACCESS_TOKEN_JWK=$(hydra get jwk hydra.jwt.access-token --endpoint $HYDRA_ADMIN_SERVICE_PATH {{- if .Values.component.sidecar.enabled }} -H "$BASIC_AUTH_HEADER" {{- end }} 2>&1 || true)
-
-                echo "Checking for existing ES256 access token key (hydra.jwt.access-token)..."
-                if echo "$ACCESS_TOKEN_JWK" | grep -q '"error": "Not Found"' || ! echo "$ACCESS_TOKEN_JWK" | grep -q "ES256"; then
-                  echo "Creating a new ES256 access token key (hydra.jwt.access-token)..."
-                  hydra create jwk hydra.jwt.access-token --alg ES256 --use sig --endpoint $HYDRA_ADMIN_SERVICE_PATH {{- if .Values.component.sidecar.enabled }} -H "$BASIC_AUTH_HEADER" {{- end }} || exit 1
-                elif echo "$ACCESS_TOKEN_JWK" | grep -q "ES256"; then
-                  echo "ES256 key for access token already exists, skipping creation."
-                else
-                  echo "Unexpected error or response: $ACCESS_TOKEN_JWK"
-                  exit 1
-                fi
-
-                ID_TOKEN_JWK=$(hydra get jwk hydra.openid.id-token --endpoint $HYDRA_ADMIN_SERVICE_PATH {{- if .Values.component.sidecar.enabled }} -H "$BASIC_AUTH_HEADER" {{- end }} 2>&1 || true)
-
-                if echo "$ID_TOKEN_JWK" | grep -q '"error": "Not Found"' || ! echo "$ID_TOKEN_JWK" | grep -q "ES256"; then
-                  echo "Creating new ES256 ID token key (hydra.openid.id-token)..."
-                  hydra create jwk hydra.openid.id-token --alg ES256 --use sig --endpoint $HYDRA_ADMIN_SERVICE_PATH {{- if .Values.component.sidecar.enabled }} -H "$BASIC_AUTH_HEADER" {{- end }} || exit 1
-                elif echo "$ID_TOKEN_JWK" | grep -q "ES256"; then
-                  echo "ES256 key for ID token already exists, skipping creation."
-                else
-                  echo "Unexpected error or response: $ID_TOKEN_JWK"
-                  exit 1
-                fi
-
-                echo "Fetching updated access token keys (hydra.jwt.access-token)..."
-                hydra get jwk hydra.jwt.access-token --endpoint $HYDRA_ADMIN_SERVICE_PATH {{- if .Values.component.sidecar.enabled }} -H "$BASIC_AUTH_HEADER" {{- end }} || exit 1
-
-                echo "Fetching updated ID token keys (hydra.openid.id-token)..."
-                hydra get jwk hydra.openid.id-token --endpoint $HYDRA_ADMIN_SERVICE_PATH {{- if .Values.component.sidecar.enabled }} -H "$BASIC_AUTH_HEADER" {{- end }} || exit 1
-              done
+            - "sh /scripts/jwks-create.sh"
+          volumeMounts:
+            - name: scripts
+              mountPath: /scripts
+              readOnly: true
+      volumes:
+        - name: scripts
+          configMap:
+            name: {{ include "iris.fullname" . }}
       restartPolicy: Never
+{{- end }}
+{{- end }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
✨ Summary
Configured Kubernetes Jobs to generate JWKs with the ES256 algorithm 

🧩 Details
- A separate Job is created for each realm.
- Jobs can be enabled by setting the job.jwk.enabled flag to true in the values.yaml file.
- Jobs access the Iris-Hydra admin endpoint directly via Kubernetes service DNS

